### PR TITLE
[0.2.1->0.2.2] Changed type of ReactUMGNodeMap from 'object' to 'Map'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-umg",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A React renderer for Unreal Motion Graphics With Unreal.js",
   "main": "index.js",
   "scripts": {

--- a/src/ReactUMGMount.js
+++ b/src/ReactUMGMount.js
@@ -141,7 +141,7 @@ const ReactUMGMount = {
 
     // needed for react-devtools
     ReactUMGMount._instancesByReactRootID[rootId] = nextComponent;
-    NodeMap[nextComponent] = umgWidget;
+    NodeMap.set(nextComponent, umgWidget);
  
     umgWidget.JavascriptContext = Context;
     umgWidget.proxy = {
@@ -215,7 +215,7 @@ const ReactUMGMount = {
         const rootId = ReactInstanceHandles.createReactRootID(widget.reactUmgId);
         delete UmgRoots[rootId];
         delete ReactUMGMount._instancesByReactRootID[rootId];
-        delete NodeMap[internalInstance];
+        NodeMap.delete(internalInstance);
       } 
       internalInstance.unmountComponent();
     }
@@ -224,7 +224,8 @@ const ReactUMGMount = {
     }
   },
   findNode(instance) {
-    return NodeMap[instance];
+    const internalInstance = ReactInstanceMap.get(instance);
+    return internalInstance && NodeMap.get(internalInstance);
   }, 
   wrap(nextElement, outer = Root.GetEngine ? JavascriptLibrary.CreatePackage(null,'/Script/Javascript') : GWorld) {
     let widget = Root.GetEngine ? new JavascriptWidget(outer) : GWorld.CreateWidget(JavascriptWidget);

--- a/src/ReactUMGNodeMap.js
+++ b/src/ReactUMGNodeMap.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = {};
+module.exports = new Map();


### PR DESCRIPTION
Changed type of ReactUMGNodeMap from object to Map for using 'object' key.
Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Objects_and_maps_compared) for details