### PR TITLE
[0.2.2->0.2.3] Incorrect handling for instanced component/widget with type name string is fixed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-umg",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A React renderer for Unreal Motion Graphics With Unreal.js",
   "main": "index.js",
   "scripts": {

--- a/src/ReactUMGMount.js
+++ b/src/ReactUMGMount.js
@@ -208,29 +208,25 @@ const ReactUMGMount = {
     return component.getPublicInstance();
   },
   unmountComponent(instance) {
-    const internalInstance = ReactInstanceMap.get(instance);
-    if (internalInstance) {
-      let widget = ReactUMGMount.findNode(internalInstance);
-      if (widget) {
-        const rootId = ReactInstanceHandles.createReactRootID(widget.reactUmgId);
-        delete UmgRoots[rootId];
-        delete ReactUMGMount._instancesByReactRootID[rootId];
-        NodeMap.delete(internalInstance);
-      } 
-      internalInstance.unmountComponent();
+    let widget = ReactUMGMount.findNode(instance);
+    if (widget) {
+      const rootId = ReactInstanceHandles.createReactRootID(widget.reactUmgId);
+      delete UmgRoots[rootId];
+      delete ReactUMGMount._instancesByReactRootID[rootId];
+      NodeMap.delete(internalInstance);
     }
-    else {
-      instance.unmountComponent();
-    }
+
+    const internalInstance = ReactInstanceMap.get(instance) || instance;
+    internalInstance.unmountComponent();
   },
   findNode(instance) {
-    const internalInstance = ReactInstanceMap.get(instance);
+    const internalInstance = ReactInstanceMap.get(instance) || instance;
     return internalInstance && NodeMap.get(internalInstance);
-  }, 
+  },
   wrap(nextElement, outer = Root.GetEngine ? JavascriptLibrary.CreatePackage(null,'/Script/Javascript') : GWorld) {
     let widget = Root.GetEngine ? new JavascriptWidget(outer) : GWorld.CreateWidget(JavascriptWidget);
     let instance = ReactUMGMount.render(nextElement, widget);
-    return ReactUMGMount.findNode(instance) 
+    return ReactUMGMount.findNode(instance)
   }
 };
 


### PR DESCRIPTION
Sorry for malfunctioning version 0.2.2. There was a bug on handling instances those are created with type name in string. It's fixed now.