### PR TITLE
[0.2.3]->[0.2.4] Problem that widgets never being removed from NodeMap is fixed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-umg",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A React renderer for Unreal Motion Graphics With Unreal.js",
   "main": "index.js",
   "scripts": {

--- a/src/ReactUMGMount.js
+++ b/src/ReactUMGMount.js
@@ -207,8 +207,9 @@ const ReactUMGMount = {
 
     return component.getPublicInstance();
   },
-  unmountComponent(instance) {
-    let widget = ReactUMGMount.findNode(instance);
+  unmountComponent(publicInstance) {
+    const internalInstance = ReactUMGMount.getInternalInstance(publicInstance);
+    let widget = NodeMap.get(internalInstance);
     if (widget) {
       const rootId = ReactInstanceHandles.createReactRootID(widget.reactUmgId);
       delete UmgRoots[rootId];
@@ -216,17 +217,25 @@ const ReactUMGMount = {
       NodeMap.delete(internalInstance);
     }
 
-    const internalInstance = ReactInstanceMap.get(instance) || instance;
     internalInstance.unmountComponent();
   },
-  findNode(instance) {
-    const internalInstance = ReactInstanceMap.get(instance) || instance;
+  getInternalInstance(publicInstance) {
+    // Reverse of ReactCompositeComponent(Wrapper).getPublicInstance
+    let internalInstance = ReactInstanceMap.get(publicInstance);
+    if (!internalInstance) {
+      // Reverse of ReactUMGComponent.getPublicInstance
+      internalInstance = publicInstance;
+    }
+    return internalInstance;
+  },
+  findNode(publicInstance) {
+    const internalInstance = ReactUMGMount.getInternalInstance(publicInstance)
     return internalInstance && NodeMap.get(internalInstance);
   },
   wrap(nextElement, outer = Root.GetEngine ? JavascriptLibrary.CreatePackage(null,'/Script/Javascript') : GWorld) {
     let widget = Root.GetEngine ? new JavascriptWidget(outer) : GWorld.CreateWidget(JavascriptWidget);
-    let instance = ReactUMGMount.render(nextElement, widget);
-    return ReactUMGMount.findNode(instance)
+    let publicInstance = ReactUMGMount.render(nextElement, widget);
+    return ReactUMGMount.findNode(publicInstance);
   }
 };
 


### PR DESCRIPTION
Sorry, again. There was a mistake while changing name of variables in 0.2.3. It caused the problem that references to component and widget in NodeMap never being removed. Now it's fixed.

And, to clarify meaning of the variable 'instance',

- its name is changed to either 'internalInstance' or 'publicInstance'.
- ReactUMGMount.getInternalInstance function is added as a reverse of getPublicInstance.